### PR TITLE
Add include() function + __file__ and __FILE__ variables

### DIFF
--- a/Harmony/22/index.d.ts
+++ b/Harmony/22/index.d.ts
@@ -18,7 +18,6 @@ declare class UI_DialogController {}
 
 /**
  * The path to the current .js file being run.
- * {@link https://discord.com/channels/559907235510222859/560516493780189195/1018886847017001031}
  * @example
  * var currentFilePath = __file__; Result: /path/to/file.js
  */
@@ -26,7 +25,6 @@ declare var __file__: string;
 
 /**
  * The name of the current .js file being run.
- * {@link https://discord.com/channels/559907235510222859/560516493780189195/1018886847017001031}
  * @example
  * var currentFileName = __FILE__; Result: file.js
  */

--- a/Harmony/22/index.d.ts
+++ b/Harmony/22/index.d.ts
@@ -17,6 +17,22 @@ declare type DD_DragObject = any;
 declare class UI_DialogController {}
 
 /**
+ * The path to the current .js file being run.
+ * {@link https://discord.com/channels/559907235510222859/560516493780189195/1018886847017001031}
+ * @example
+ * var currentFilePath = __file__; Result: /path/to/file.js
+ */
+declare var __file__: string;
+
+/**
+ * The name of the current .js file being run.
+ * {@link https://discord.com/channels/559907235510222859/560516493780189195/1018886847017001031}
+ * @example
+ * var currentFileName = __FILE__; Result: file.js
+ */
+declare var __FILE__: string;
+
+/**
  * The specialFolders JavaScript global object. Provide the path to application specific paths.
  * By using the SpecialFolders functions, you can retrieve information about the different folders
  * (directories) used by the application. All of the functions are read-only. They return strings that
@@ -12229,6 +12245,11 @@ declare class DrawingToolParams extends QObject {
    */
   // /* Invalid - Duplicate property name */ wasCanceled: boolean;
 }
+
+/**
+ * Include contents of a Javascript file.
+ */
+declare function include(jsPath: string);
 
 /**
  * The File JavaScript class. Open, close, read, write, get information about files.


### PR DESCRIPTION
`__file__` and `__FILE__ `are exposed by the JS interpreter as variables you can read... `__file__` is the filepath to the currently executing file. `__FILE__` is the name of that file with no path
[Discord discussion](https://discord.com/channels/559907235510222859/560516493780189195/1018850360309338153)